### PR TITLE
Add configuration template and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,13 @@
 # Hoteles
 
 Estructura básica para el proyecto Hoteles.
+
+## Configuración
+
+Para iniciar, duplica el archivo de ejemplo y renómbralo:
+
+```bash
+cp config.example.json config.json
+```
+
+Luego reemplaza los valores `<REPLACE_ME>` y `<REPLACE_ME_URL>` por la información real del sitio.

--- a/config.example.json
+++ b/config.example.json
@@ -3,6 +3,54 @@
   Author: ChatGPT
 */
 {
-  "apiUrl": "https://example.com/api",
-  "port": 3000
+  "site": {
+    "title": "<REPLACE_ME>",
+    "description": "<REPLACE_ME>",
+    "baseUrl": "<REPLACE_ME_URL>"
+  },
+  "contact": {
+    "email": "<REPLACE_ME>",
+    "phone": "<REPLACE_ME>",
+    "address": "<REPLACE_ME>"
+  },
+  "booking": {
+    "ctaText": "<REPLACE_ME>",
+    "ctaUrl": "<REPLACE_ME_URL>"
+  },
+  "branding": {
+    "logoUrl": "<REPLACE_ME_URL>",
+    "faviconUrl": "<REPLACE_ME_URL>"
+  },
+  "nav": [
+    { "label": "<REPLACE_ME>", "href": "<REPLACE_ME_URL>" },
+    { "label": "<REPLACE_ME>", "href": "<REPLACE_ME_URL>" }
+  ],
+  "rooms": [
+    {
+      "name": "<REPLACE_ME>",
+      "imageUrl": "<REPLACE_ME_URL>",
+      "description": "<REPLACE_ME>"
+    }
+  ],
+  "amenities": [
+    {
+      "iconUrl": "<REPLACE_ME_URL>",
+      "label": "<REPLACE_ME>"
+    }
+  ],
+  "gallery": [
+    "<REPLACE_ME_URL>"
+  ],
+  "testimonials": [
+    {
+      "author": "<REPLACE_ME>",
+      "quote": "<REPLACE_ME>",
+      "avatarUrl": "<REPLACE_ME_URL>"
+    }
+  ],
+  "seo": {
+    "metaTitle": "<REPLACE_ME>",
+    "metaDescription": "<REPLACE_ME>",
+    "metaImageUrl": "<REPLACE_ME_URL>"
+  }
 }


### PR DESCRIPTION
## Summary
- add example `config.example.json` with placeholders for site, contact, booking, branding, nav, rooms, amenities, gallery, testimonials, and seo
- document how to duplicate `config.example.json` to `config.json`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae14af0c188329b8869b199505aeb3