### PR TITLE
feat: add configuration loading and multilingual UI

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,4 +1,91 @@
 // Purpose: Main JavaScript functionality for the hoteles project.
 // Author: ChatGPT
 
-console.log('Bienvenido a Hoteles');
+let config = {};
+let currentLang = 'es';
+
+const texts = {
+  es: {
+    headerTitle: 'Bienvenido a Hoteles',
+    heroTitle: 'Disfruta tu estadía',
+    bookingCta: 'Reservar ahora',
+    seo: {
+      metaTitle: 'Hotel Paraíso',
+      metaDescription: 'Descubre el mejor alojamiento.'
+    }
+  },
+  en: {
+    headerTitle: 'Welcome to Hotels',
+    heroTitle: 'Enjoy your stay',
+    bookingCta: 'Book now',
+    seo: {
+      metaTitle: 'Paradise Hotel',
+      metaDescription: 'Discover the best accommodation.'
+    }
+  }
+};
+
+async function loadConfig() {
+  try {
+    const res = await fetch('config.json');
+    if (!res.ok) throw new Error('config.json not found');
+    return await res.json();
+  } catch (_) {
+    const res = await fetch('config.example.json');
+    return await res.json();
+  }
+}
+
+function setColors() {
+  if (!config.colors) return;
+  Object.entries(config.colors).forEach(([key, value]) => {
+    document.documentElement.style.setProperty(`--color-${key}`, value);
+  });
+}
+
+function applySEO(lang) {
+  const langSeo = (texts[lang] && texts[lang].seo) || {};
+  const metaTitle = langSeo.metaTitle || (config.seo && config.seo.metaTitle) || '';
+  const metaDescription =
+    langSeo.metaDescription || (config.seo && config.seo.metaDescription) || '';
+  document.title = metaTitle;
+  document.getElementById('meta-description').setAttribute('content', metaDescription);
+  document.getElementById('og-title').setAttribute('content', metaTitle);
+  document.getElementById('og-description').setAttribute('content', metaDescription);
+  if (config.seo && config.seo.metaImageUrl) {
+    document.getElementById('og-image').setAttribute('content', config.seo.metaImageUrl);
+  }
+}
+
+function renderUI(lang) {
+  const dict = texts[lang] || {};
+  const headerEl = document.getElementById('header-title');
+  const heroEl = document.getElementById('hero-title');
+  const bookingBtn = document.getElementById('booking-cta');
+  if (headerEl) headerEl.textContent = dict.headerTitle || '';
+  if (heroEl) heroEl.textContent = dict.heroTitle || '';
+  if (bookingBtn) bookingBtn.textContent = dict.bookingCta || '';
+}
+
+function setLanguage(lang) {
+  currentLang = lang;
+  renderUI(lang);
+  applySEO(lang);
+  localStorage.setItem('lang', lang);
+  const selector = document.getElementById('language-selector');
+  if (selector && selector.value !== lang) {
+    selector.value = lang;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  config = await loadConfig();
+  setColors();
+  const stored = localStorage.getItem('lang');
+  const defaultLang = (config.site && config.site.defaultLang) || 'es';
+  setLanguage(stored || defaultLang);
+  const selector = document.getElementById('language-selector');
+  if (selector) {
+    selector.addEventListener('change', (e) => setLanguage(e.target.value));
+  }
+});

--- a/config.example.json
+++ b/config.example.json
@@ -6,7 +6,12 @@
   "site": {
     "title": "<REPLACE_ME>",
     "description": "<REPLACE_ME>",
-    "baseUrl": "<REPLACE_ME_URL>"
+    "baseUrl": "<REPLACE_ME_URL>",
+    "defaultLang": "es"
+  },
+  "colors": {
+    "primary": "<REPLACE_ME_HEX>",
+    "secondary": "<REPLACE_ME_HEX>"
   },
   "contact": {
     "email": "<REPLACE_ME>",

--- a/config.json
+++ b/config.json
@@ -1,0 +1,17 @@
+{
+  "site": {
+    "title": "Hotel Paraíso",
+    "description": "Tu hogar lejos de casa",
+    "baseUrl": "https://hotelparaiso.example",
+    "defaultLang": "es"
+  },
+  "colors": {
+    "primary": "#005f73",
+    "secondary": "#0a9396"
+  },
+  "seo": {
+    "metaTitle": "Hotel Paraíso",
+    "metaDescription": "Descubre el mejor alojamiento.",
+    "metaImageUrl": "assets/img/og-image.png"
+  }
+}

--- a/index.html
+++ b/index.html
@@ -16,13 +16,23 @@
 </head>
 <body>
   <!-- Section: Header -->
-  <header id="header"></header>
+  <header id="header">
+    <h1 id="header-title"></h1>
+    <select id="language-selector">
+      <option value="es">ES</option>
+      <option value="en">EN</option>
+    </select>
+  </header>
 
   <!-- Section: Hero -->
-  <section id="hero"></section>
+  <section id="hero">
+    <h2 id="hero-title"></h2>
+  </section>
 
   <!-- Section: Booking -->
-  <section id="booking"></section>
+  <section id="booking">
+    <button id="booking-cta"></button>
+  </section>
 
   <!-- Section: Rooms -->
   <section id="rooms"></section>


### PR DESCRIPTION
## Summary
- load configuration from `config.json` with fallback to `config.example.json`
- initialize CSS variables and meta tags based on configuration
- add static translation dictionary and language selector with persistence

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_68ae346b0eb48329a9c4885914bda742