### PR TITLE
Add fixed header with navigation and language switcher

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -35,6 +35,47 @@ body {
   background-color: var(--color-bg);
 }
 
+header {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--color-bg);
+  z-index: 1000;
+}
+
+main {
+  padding-top: 60px;
+}
+
+#nav-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: var(--spacing-md);
+}
+
+#nav-items a {
+  text-decoration: none;
+  color: inherit;
+}
+
+.logo-text {
+  font-weight: bold;
+  font-size: 1.25rem;
+}
+
+a:focus,
+button:focus,
+select:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 /* Utility classes */
 .btn {
   display: inline-block;

--- a/assets/img/logo.svg
+++ b/assets/img/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 20">
+  <text x="0" y="15" font-size="15" fill="currentColor">Hotel</text>
+</svg>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -57,14 +57,46 @@ function applySEO(lang) {
   }
 }
 
+function renderLogo() {
+  const logoEl = document.getElementById('logo');
+  if (!logoEl) return;
+  logoEl.innerHTML = '';
+  if (config.site && config.site.logo) {
+    const img = document.createElement('img');
+    img.src = config.site.logo;
+    img.alt = (config.site && config.site.title) || 'Logo';
+    logoEl.appendChild(img);
+  } else {
+    const span = document.createElement('span');
+    span.className = 'logo-text';
+    span.textContent = (config.site && config.site.title) || '';
+    logoEl.appendChild(span);
+  }
+}
+
+function renderNav(lang) {
+  const list = document.getElementById('nav-items');
+  if (!list || !config.nav || !Array.isArray(config.nav.items)) return;
+  list.innerHTML = '';
+  config.nav.items.forEach((item) => {
+    const li = document.createElement('li');
+    const a = document.createElement('a');
+    a.href = `#${item.section}`;
+    const label = (item.label && (item.label[lang] || item.label)) || '';
+    a.textContent = label;
+    a.setAttribute('tabindex', '0');
+    li.appendChild(a);
+    list.appendChild(li);
+  });
+}
+
 function renderUI(lang) {
   const dict = texts[lang] || {};
-  const headerEl = document.getElementById('header-title');
   const heroEl = document.getElementById('hero-title');
   const bookingBtn = document.getElementById('booking-cta');
-  if (headerEl) headerEl.textContent = dict.headerTitle || '';
   if (heroEl) heroEl.textContent = dict.heroTitle || '';
   if (bookingBtn) bookingBtn.textContent = dict.bookingCta || '';
+  renderNav(lang);
 }
 
 function setLanguage(lang) {
@@ -72,7 +104,7 @@ function setLanguage(lang) {
   renderUI(lang);
   applySEO(lang);
   localStorage.setItem('lang', lang);
-  const selector = document.getElementById('language-selector');
+  const selector = document.getElementById('langSwitcher');
   if (selector && selector.value !== lang) {
     selector.value = lang;
   }
@@ -80,12 +112,20 @@ function setLanguage(lang) {
 
 document.addEventListener('DOMContentLoaded', async () => {
   config = await loadConfig();
+  renderLogo();
   setColors();
   const stored = localStorage.getItem('lang');
   const defaultLang = (config.site && config.site.defaultLang) || 'es';
   setLanguage(stored || defaultLang);
-  const selector = document.getElementById('language-selector');
+  const selector = document.getElementById('langSwitcher');
   if (selector) {
     selector.addEventListener('change', (e) => setLanguage(e.target.value));
+  }
+  const reserveBtn = document.getElementById('reserve-btn');
+  if (reserveBtn) {
+    reserveBtn.addEventListener('click', () => {
+      const widget = document.getElementById('booking');
+      if (widget) widget.scrollIntoView({ behavior: 'smooth' });
+    });
   }
 });

--- a/config.json
+++ b/config.json
@@ -3,7 +3,8 @@
     "title": "Hotel Paraíso",
     "description": "Tu hogar lejos de casa",
     "baseUrl": "https://hotelparaiso.example",
-    "defaultLang": "es"
+    "defaultLang": "es",
+    "logo": "assets/img/logo.svg"
   },
   "colors": {
     "primary": "#005f73",
@@ -13,5 +14,14 @@
     "metaTitle": "Hotel Paraíso",
     "metaDescription": "Descubre el mejor alojamiento.",
     "metaImageUrl": "assets/img/og-image.png"
+  },
+  "nav": {
+    "items": [
+      { "section": "hero", "label": { "es": "Inicio", "en": "Home" } },
+      { "section": "rooms", "label": { "es": "Habitaciones", "en": "Rooms" } },
+      { "section": "amenities", "label": { "es": "Servicios", "en": "Amenities" } },
+      { "section": "gallery", "label": { "es": "Galería", "en": "Gallery" } },
+      { "section": "location", "label": { "es": "Ubicación", "en": "Location" } }
+    ]
   }
 }

--- a/index.html
+++ b/index.html
@@ -17,34 +17,40 @@
 <body>
   <!-- Section: Header -->
   <header id="header">
-    <h1 id="header-title"></h1>
-    <select id="language-selector">
+    <a href="#hero" id="logo"></a>
+    <nav id="nav" aria-label="Principal">
+      <ul id="nav-items"></ul>
+    </nav>
+    <select id="langSwitcher" aria-label="Cambiar idioma">
       <option value="es">ES</option>
       <option value="en">EN</option>
     </select>
+    <button id="reserve-btn" class="btn btn-primary">Reservar</button>
   </header>
 
-  <!-- Section: Hero -->
-  <section id="hero">
-    <h2 id="hero-title"></h2>
-  </section>
+  <main>
+    <!-- Section: Hero -->
+    <section id="hero">
+      <h2 id="hero-title"></h2>
+    </section>
 
-  <!-- Section: Booking -->
-  <section id="booking">
-    <button id="booking-cta"></button>
-  </section>
+    <!-- Section: Booking -->
+    <section id="booking">
+      <button id="booking-cta"></button>
+    </section>
 
-  <!-- Section: Rooms -->
-  <section id="rooms"></section>
+    <!-- Section: Rooms -->
+    <section id="rooms"></section>
 
-  <!-- Section: Amenities -->
-  <section id="amenities"></section>
+    <!-- Section: Amenities -->
+    <section id="amenities"></section>
 
-  <!-- Section: Gallery -->
-  <section id="gallery"></section>
+    <!-- Section: Gallery -->
+    <section id="gallery"></section>
 
-  <!-- Section: Location -->
-  <section id="location"></section>
+    <!-- Section: Location -->
+    <section id="location"></section>
+  </main>
 
   <!-- Section: Footer -->
   <footer id="footer"></footer>


### PR DESCRIPTION
## Summary
- build fixed header with configurable navigation and logo
- add language switcher and reservation button scrolling to booking widget
- style header for accessibility with focus outlines and smooth scrolling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae351ca0208329a76498e453a706b3