### PR TITLE
feat: add responsive hero section

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -35,6 +35,12 @@ body {
   background-color: var(--color-bg);
 }
 
+.container {
+  width: min(100% - 2rem, 1200px);
+  margin-inline: auto;
+  padding: var(--spacing-lg) var(--spacing-md);
+}
+
 header {
   position: fixed;
   top: 0;
@@ -93,6 +99,11 @@ select:focus {
   color: var(--color-text-light);
 }
 
+.btn-secondary {
+  background-color: var(--color-accent);
+  color: var(--color-text-dark);
+}
+
 .grid {
   display: grid;
   gap: var(--spacing-md);
@@ -138,6 +149,52 @@ select:focus {
   background-color: var(--color-bg);
   padding: var(--spacing-lg);
   border-radius: 8px;
+}
+
+/* Hero section */
+#hero {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 70vh;
+  color: var(--color-text-light);
+  background-size: cover;
+  background-position: center;
+  text-align: center;
+}
+
+#hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+#hero.hero-no-image {
+  background-color: var(--color-primary);
+}
+
+#hero .container {
+  position: relative;
+  z-index: 1;
+}
+
+.hero-actions {
+  margin-top: var(--spacing-lg);
+  display: flex;
+  gap: var(--spacing-md);
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+@media (min-width: 768px) {
+  #hero .container {
+    text-align: left;
+  }
+  .hero-actions {
+    justify-content: flex-start;
+  }
 }
 
 /* High contrast mode */

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -6,8 +6,8 @@ let currentLang = 'es';
 
 const texts = {
   es: {
-    headerTitle: 'Bienvenido a Hoteles',
-    heroTitle: 'Disfruta tu estadía',
+    heroRoomsBtn: 'Ver habitaciones',
+    heroReserveBtn: 'Reservar',
     bookingCta: 'Reservar ahora',
     seo: {
       metaTitle: 'Hotel Paraíso',
@@ -15,8 +15,8 @@ const texts = {
     }
   },
   en: {
-    headerTitle: 'Welcome to Hotels',
-    heroTitle: 'Enjoy your stay',
+    heroRoomsBtn: 'View rooms',
+    heroReserveBtn: 'Book',
     bookingCta: 'Book now',
     seo: {
       metaTitle: 'Paradise Hotel',
@@ -90,13 +90,38 @@ function renderNav(lang) {
   });
 }
 
+function renderHero(lang) {
+  const heroSection = document.getElementById('hero');
+  if (!heroSection) return;
+  const heading = document.getElementById('hero-heading');
+  const tagline = document.getElementById('hero-tagline');
+  const roomsBtn = document.getElementById('hero-rooms-btn');
+  const reserveBtn = document.getElementById('hero-reserve-btn');
+  const name = (config.site && (config.site.name || config.site.title)) || '';
+  const tag =
+    (config.site &&
+      config.site.tagline &&
+      (config.site.tagline[lang] || config.site.tagline)) || '';
+  if (heading) heading.textContent = name;
+  if (tagline) tagline.textContent = tag;
+  const dict = texts[lang] || {};
+  if (roomsBtn) roomsBtn.textContent = dict.heroRoomsBtn || 'Ver habitaciones';
+  if (reserveBtn) reserveBtn.textContent = dict.heroReserveBtn || 'Reservar';
+  if (config.site && config.site.heroImage) {
+    heroSection.style.backgroundImage = `url(${config.site.heroImage})`;
+    heroSection.classList.remove('hero-no-image');
+  } else {
+    heroSection.style.backgroundImage = '';
+    heroSection.classList.add('hero-no-image');
+  }
+}
+
 function renderUI(lang) {
   const dict = texts[lang] || {};
-  const heroEl = document.getElementById('hero-title');
   const bookingBtn = document.getElementById('booking-cta');
-  if (heroEl) heroEl.textContent = dict.heroTitle || '';
   if (bookingBtn) bookingBtn.textContent = dict.bookingCta || '';
   renderNav(lang);
+  renderHero(lang);
 }
 
 function setLanguage(lang) {

--- a/config.example.json
+++ b/config.example.json
@@ -4,10 +4,13 @@
 */
 {
   "site": {
+    "name": "<REPLACE_ME>",
+    "tagline": { "es": "<REPLACE_ME>", "en": "<REPLACE_ME>" },
     "title": "<REPLACE_ME>",
     "description": "<REPLACE_ME>",
     "baseUrl": "<REPLACE_ME_URL>",
-    "defaultLang": "es"
+    "defaultLang": "es",
+    "heroImage": "<REPLACE_ME_URL>"
   },
   "colors": {
     "primary": "<REPLACE_ME_HEX>",

--- a/config.json
+++ b/config.json
@@ -1,5 +1,10 @@
 {
   "site": {
+    "name": "Hotel Paraíso",
+    "tagline": {
+      "es": "Tu hogar lejos de casa",
+      "en": "Your home away from home"
+    },
     "title": "Hotel Paraíso",
     "description": "Tu hogar lejos de casa",
     "baseUrl": "https://hotelparaiso.example",

--- a/index.html
+++ b/index.html
@@ -31,7 +31,14 @@
   <main>
     <!-- Section: Hero -->
     <section id="hero">
-      <h2 id="hero-title"></h2>
+      <div class="container">
+        <h1 id="hero-heading"></h1>
+        <p id="hero-tagline"></p>
+        <div class="hero-actions">
+          <a href="#rooms" id="hero-rooms-btn" class="btn btn-secondary">Ver habitaciones</a>
+          <a href="#booking" id="hero-reserve-btn" class="btn btn-primary">Reservar</a>
+        </div>
+      </div>
     </section>
 
     <!-- Section: Booking -->


### PR DESCRIPTION
## Summary
- build hero section with dynamic name, tagline, and action buttons
- style hero for responsive layout, high contrast, and background image fallback
- expose site name and tagline in config for localization

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check assets/js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae365ae7288329811fc64f293898ef