### PR TITLE
feat: add booking form and validation

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -16,15 +16,16 @@
     "primary": "<REPLACE_ME_HEX>",
     "secondary": "<REPLACE_ME_HEX>"
   },
-  "contact": {
-    "email": "<REPLACE_ME>",
-    "phone": "<REPLACE_ME>",
-    "address": "<REPLACE_ME>"
-  },
-  "booking": {
-    "ctaText": "<REPLACE_ME>",
-    "ctaUrl": "<REPLACE_ME_URL>"
-  },
+    "contact": {
+      "email": "<REPLACE_ME>",
+      "phone": "<REPLACE_ME>",
+      "address": "<REPLACE_ME>",
+      "whatsapp": "<REPLACE_ME>"
+    },
+    "booking": {
+      "mode": "whatsapp",
+      "externalUrl": "<REPLACE_ME_URL>"
+    },
   "branding": {
     "logoUrl": "<REPLACE_ME_URL>",
     "faviconUrl": "<REPLACE_ME_URL>"

--- a/config.json
+++ b/config.json
@@ -20,6 +20,13 @@
     "metaDescription": "Descubre el mejor alojamiento.",
     "metaImageUrl": "assets/img/og-image.png"
   },
+  "contact": {
+    "whatsapp": "1234567890"
+  },
+  "booking": {
+    "mode": "whatsapp",
+    "externalUrl": "https://booking.example"
+  },
   "nav": {
     "items": [
       { "section": "hero", "label": { "es": "Inicio", "en": "Home" } },

--- a/index.html
+++ b/index.html
@@ -42,9 +42,26 @@
     </section>
 
     <!-- Section: Booking -->
-    <section id="booking">
-      <button id="booking-cta"></button>
-    </section>
+      <section id="booking">
+        <form id="booking-form" novalidate>
+          <div class="field">
+            <label for="checkin">Check-in</label>
+            <input type="date" id="checkin" name="checkin" required />
+            <span class="error" id="checkin-error" aria-live="polite"></span>
+          </div>
+          <div class="field">
+            <label for="checkout">Check-out</label>
+            <input type="date" id="checkout" name="checkout" required />
+            <span class="error" id="checkout-error" aria-live="polite"></span>
+          </div>
+          <div class="field">
+            <label for="guests">Huéspedes</label>
+            <input type="number" id="guests" name="guests" min="1" required />
+            <span class="error" id="guests-error" aria-live="polite"></span>
+          </div>
+          <button type="submit" id="booking-cta"></button>
+        </form>
+      </section>
 
     <!-- Section: Rooms -->
     <section id="rooms"></section>


### PR DESCRIPTION
## Summary
- add booking form with check-in, check-out and guests fields
- validate booking data and handle WhatsApp or external redirect
- extend config examples with WhatsApp and booking settings

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3840aab48329bb1553523db66888