### PR TITLE
Render room cards with modal details

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -117,6 +117,18 @@ select:focus {
   padding: var(--spacing-md);
 }
 
+.room-card img {
+  width: 100%;
+  height: auto;
+  border-radius: 4px;
+}
+
+.rooms-grid {
+  display: grid;
+  gap: var(--spacing-md);
+  grid-template-columns: 1fr;
+}
+
 .sr-only {
   position: absolute;
   width: 1px;
@@ -228,6 +240,18 @@ select:focus {
 @media (min-width: 1280px) {
   .grid {
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  }
+}
+
+@media (min-width: 768px) {
+  .rooms-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  .rooms-grid {
+    grid-template-columns: repeat(3, 1fr);
   }
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -116,12 +116,98 @@ function renderHero(lang) {
   }
 }
 
+function openRoomModal(room, lang) {
+  let modal = document.getElementById('room-modal');
+  if (!modal) {
+    modal = document.createElement('div');
+    modal.id = 'room-modal';
+    modal.className = 'modal';
+    modal.addEventListener('click', (e) => {
+      if (e.target === modal) modal.classList.remove('active');
+    });
+    document.body.appendChild(modal);
+  }
+  modal.innerHTML = '';
+  const content = document.createElement('div');
+  content.className = 'modal-content';
+  const close = document.createElement('button');
+  close.className = 'btn btn-secondary';
+  close.textContent = 'Cerrar';
+  close.addEventListener('click', () => modal.classList.remove('active'));
+  const details =
+    typeof room.details === 'object' ? room.details[lang] || room.details : room.details;
+  const detailsWrap = document.createElement('div');
+  detailsWrap.innerHTML = details || '';
+  content.appendChild(detailsWrap);
+  content.appendChild(close);
+  modal.appendChild(content);
+  modal.classList.add('active');
+}
+
+function renderRooms(lang) {
+  const section = document.getElementById('rooms');
+  if (!section) return;
+  if (!config.rooms || !Array.isArray(config.rooms) || config.rooms.length === 0) {
+    section.style.display = 'none';
+    return;
+  }
+  section.style.display = '';
+  section.innerHTML = '';
+  const container = document.createElement('div');
+  container.className = 'container';
+  const grid = document.createElement('div');
+  grid.className = 'rooms-grid';
+  container.appendChild(grid);
+  config.rooms.forEach((room) => {
+    const article = document.createElement('article');
+    article.className = 'card room-card';
+    if (room.image) {
+      const img = document.createElement('img');
+      img.src = room.image;
+      img.alt =
+        (typeof room.name === 'object' ? room.name[lang] || room.name : room.name) || '';
+      article.appendChild(img);
+    }
+    const title = document.createElement('h3');
+    title.textContent =
+      (typeof room.name === 'object' ? room.name[lang] || room.name : room.name) || '';
+    article.appendChild(title);
+    if (room.description) {
+      const desc = document.createElement('p');
+      desc.textContent =
+        typeof room.description === 'object'
+          ? room.description[lang] || room.description
+          : room.description;
+      article.appendChild(desc);
+    }
+    if (typeof room.price !== 'undefined' && config.booking && config.booking.currency) {
+      const priceEl = document.createElement('p');
+      const fmt = new Intl.NumberFormat(lang, {
+        style: 'currency',
+        currency: config.booking.currency
+      });
+      priceEl.textContent = `Desde ${fmt.format(room.price)}`;
+      article.appendChild(priceEl);
+    }
+    if (room.details) {
+      const btn = document.createElement('button');
+      btn.className = 'btn btn-secondary';
+      btn.textContent = 'Más info';
+      btn.addEventListener('click', () => openRoomModal(room, lang));
+      article.appendChild(btn);
+    }
+    grid.appendChild(article);
+  });
+  section.appendChild(container);
+}
+
 function renderUI(lang) {
   const dict = texts[lang] || {};
   const bookingBtn = document.getElementById('booking-cta');
   if (bookingBtn) bookingBtn.textContent = dict.bookingCta || '';
   renderNav(lang);
   renderHero(lang);
+  renderRooms(lang);
 }
 
 function setLanguage(lang) {

--- a/config.example.json
+++ b/config.example.json
@@ -24,7 +24,8 @@
     },
     "booking": {
       "mode": "whatsapp",
-      "externalUrl": "<REPLACE_ME_URL>"
+      "externalUrl": "<REPLACE_ME_URL>",
+      "currency": "<REPLACE_ME_CURRENCY>"
     },
   "branding": {
     "logoUrl": "<REPLACE_ME_URL>",
@@ -37,8 +38,10 @@
   "rooms": [
     {
       "name": "<REPLACE_ME>",
-      "imageUrl": "<REPLACE_ME_URL>",
-      "description": "<REPLACE_ME>"
+      "image": "<REPLACE_ME_URL>",
+      "description": "<REPLACE_ME>",
+      "price": 0,
+      "details": "<REPLACE_ME>"
     }
   ],
   "amenities": [

--- a/config.json
+++ b/config.json
@@ -25,7 +25,8 @@
   },
   "booking": {
     "mode": "whatsapp",
-    "externalUrl": "https://booking.example"
+    "externalUrl": "https://booking.example",
+    "currency": "USD"
   },
   "nav": {
     "items": [
@@ -35,5 +36,35 @@
       { "section": "gallery", "label": { "es": "Galería", "en": "Gallery" } },
       { "section": "location", "label": { "es": "Ubicación", "en": "Location" } }
     ]
-  }
+  },
+  "rooms": [
+    {
+      "name": {
+        "es": "Suite Deluxe",
+        "en": "Deluxe Suite"
+      },
+      "image": "https://via.placeholder.com/400x300",
+      "description": {
+        "es": "Suite con vista al mar",
+        "en": "Suite with sea view"
+      },
+      "price": 150,
+      "details": {
+        "es": "<p>Amplia suite con balcón privado y <strong>wifi</strong>.</p>",
+        "en": "<p>Spacious suite with private balcony and <strong>wifi</strong>.</p>"
+      }
+    },
+    {
+      "name": {
+        "es": "Habitación Estándar",
+        "en": "Standard Room"
+      },
+      "image": "https://via.placeholder.com/400x300",
+      "description": {
+        "es": "Habitación confortable",
+        "en": "Comfortable room"
+      },
+      "price": 90
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Render rooms from config with cards, prices and optional modal details
- Hide rooms section when no rooms in config
- Add responsive grid styles for room cards
- Provide sample rooms and currency in config

## Testing
- `node --check assets/js/main.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3928ac448329b345cfb724351d38