### PR TITLE
Add accessible location section with contact details

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -240,6 +240,43 @@ select:focus {
   }
 }
 
+/* Location section */
+#location {
+  background-color: var(--color-bg);
+}
+
+.contact-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 var(--spacing-md) 0;
+}
+
+.contact-list li {
+  margin-bottom: var(--spacing-sm);
+}
+
+.contact-list a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.contact-list a:focus,
+.contact-list a:hover {
+  text-decoration: underline;
+}
+
+#location iframe {
+  width: 100%;
+  height: 300px;
+  border: 0;
+  margin-top: var(--spacing-md);
+}
+
+#location .btn {
+  margin-right: var(--spacing-sm);
+  margin-top: var(--spacing-md);
+}
+
 /* High contrast mode */
 .high-contrast {
   --color-primary: #000000;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -11,6 +11,14 @@ const texts = {
     heroRoomsBtn: 'Ver habitaciones',
     heroReserveBtn: 'Reservar',
     bookingCta: 'Reservar ahora',
+    contact: {
+      phone: 'Teléfono',
+      whatsapp: 'WhatsApp',
+      email: 'Email',
+      address: 'Dirección',
+      openMap: 'Abrir mapa',
+      directions: 'Cómo llegar'
+    },
     seo: {
       metaTitle: 'Hotel Paraíso',
       metaDescription: 'Descubre el mejor alojamiento.'
@@ -20,6 +28,14 @@ const texts = {
     heroRoomsBtn: 'View rooms',
     heroReserveBtn: 'Book',
     bookingCta: 'Book now',
+    contact: {
+      phone: 'Phone',
+      whatsapp: 'WhatsApp',
+      email: 'Email',
+      address: 'Address',
+      openMap: 'Open map',
+      directions: 'Directions'
+    },
     seo: {
       metaTitle: 'Paradise Hotel',
       metaDescription: 'Discover the best accommodation.'
@@ -306,6 +322,93 @@ function renderGallery() {
   section.appendChild(container);
 }
 
+function renderLocation(lang) {
+  const section = document.getElementById('location');
+  if (!section || !config.contact) return;
+  section.innerHTML = '';
+  const container = document.createElement('div');
+  container.className = 'container';
+
+  const labels = (texts[lang] && texts[lang].contact) || {};
+  const list = document.createElement('ul');
+  list.className = 'contact-list';
+
+  if (config.contact.phone) {
+    const li = document.createElement('li');
+    const a = document.createElement('a');
+    a.href = `tel:${config.contact.phone}`;
+    a.textContent = `${labels.phone || 'Teléfono'}: ${config.contact.phone}`;
+    li.appendChild(a);
+    list.appendChild(li);
+  }
+  if (config.contact.whatsapp) {
+    const li = document.createElement('li');
+    const a = document.createElement('a');
+    a.href = `https://wa.me/${config.contact.whatsapp}`;
+    a.textContent = `${labels.whatsapp || 'WhatsApp'}: ${config.contact.whatsapp}`;
+    a.target = '_blank';
+    a.rel = 'noopener';
+    li.appendChild(a);
+    list.appendChild(li);
+  }
+  if (config.contact.email) {
+    const li = document.createElement('li');
+    const a = document.createElement('a');
+    a.href = `mailto:${config.contact.email}`;
+    a.textContent = `${labels.email || 'Email'}: ${config.contact.email}`;
+    li.appendChild(a);
+    list.appendChild(li);
+  }
+  if (config.contact.address) {
+    const li = document.createElement('li');
+    const encoded = encodeURIComponent(config.contact.address);
+    const a = document.createElement('a');
+    a.href = `https://www.google.com/maps?q=${encoded}`;
+    a.textContent = `${labels.address || 'Dirección'}: ${config.contact.address}`;
+    a.target = '_blank';
+    a.rel = 'noopener';
+    li.appendChild(a);
+    list.appendChild(li);
+  }
+
+  container.appendChild(list);
+
+  if (config.contact.mapEmbedUrl) {
+    const iframe = document.createElement('iframe');
+    iframe.src = config.contact.mapEmbedUrl;
+    iframe.width = '100%';
+    iframe.height = '300';
+    iframe.style.border = '0';
+    iframe.setAttribute('loading', 'lazy');
+    iframe.setAttribute('title', 'Mapa');
+    container.appendChild(iframe);
+  } else if (config.contact.address) {
+    const mapLink = document.createElement('a');
+    mapLink.href = `https://www.google.com/maps?q=${encodeURIComponent(
+      config.contact.address
+    )}`;
+    mapLink.textContent = labels.openMap || 'Abrir mapa';
+    mapLink.className = 'btn btn-secondary';
+    mapLink.target = '_blank';
+    mapLink.rel = 'noopener';
+    container.appendChild(mapLink);
+  }
+
+  if (config.contact.address) {
+    const dirBtn = document.createElement('a');
+    dirBtn.href = `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(
+      config.contact.address
+    )}`;
+    dirBtn.textContent = labels.directions || 'Cómo llegar';
+    dirBtn.className = 'btn btn-primary';
+    dirBtn.target = '_blank';
+    dirBtn.rel = 'noopener';
+    container.appendChild(dirBtn);
+  }
+
+  section.appendChild(container);
+}
+
 function handleGalleryKeys(e) {
   const modal = document.getElementById('gallery-modal');
   if (!modal || !modal.classList.contains('active')) return;
@@ -332,6 +435,7 @@ function renderUI(lang) {
   renderRooms(lang);
   renderAmenities(lang);
   renderGallery();
+  renderLocation(lang);
 }
 
 function setLanguage(lang) {

--- a/config.example.json
+++ b/config.example.json
@@ -20,7 +20,8 @@
       "email": "<REPLACE_ME>",
       "phone": "<REPLACE_ME>",
       "address": "<REPLACE_ME>",
-      "whatsapp": "<REPLACE_ME>"
+      "whatsapp": "<REPLACE_ME>",
+      "mapEmbedUrl": "<REPLACE_ME_URL>"
     },
     "booking": {
       "mode": "whatsapp",

--- a/config.json
+++ b/config.json
@@ -21,7 +21,11 @@
     "metaImageUrl": "assets/img/og-image.png"
   },
   "contact": {
-    "whatsapp": "1234567890"
+    "phone": "555123456",
+    "whatsapp": "1234567890",
+    "email": "info@hotelparaiso.example",
+    "address": "Calle Principal 123, Ciudad, País",
+    "mapEmbedUrl": "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3151.8354345096185!2d144.96305791590477!3d-37.816279742021215!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x0!2zMzfCsDQ5JzAxLjIiUyAxNDTCsDU3JzQ3LjQiRQ!5e0!3m2!1ses!2sus!4v1610000000000!5m2!1ses!2sus"
   },
   "booking": {
     "mode": "whatsapp",


### PR DESCRIPTION
## Summary
- render contact/location section with map embed or link fallback
- show phone, WhatsApp, email and address with accessible links
- add "Cómo llegar" button and corresponding configuration options

## Testing
- `npm test` *(fails: could not read package.json)*
- `node --check assets/js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae3c800a448329b236d70ceeb817bb