### PR TITLE
Add accessible footer with contact info

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -329,3 +329,30 @@ select:focus {
   }
 }
 
+
+/* Footer */
+footer {
+  background-color: var(--color-primary);
+  color: var(--color-text-light);
+  padding: var(--spacing-lg) var(--spacing-md);
+  text-align: center;
+}
+
+.footer-links {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 var(--spacing-md);
+}
+
+.footer-links li + li {
+  margin-top: var(--spacing-sm);
+}
+
+.footer-links a {
+  color: var(--color-text-light);
+  text-decoration: underline;
+}
+
+footer p {
+  margin: 0;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -409,6 +409,32 @@ function renderLocation(lang) {
   section.appendChild(container);
 }
 
+function renderFooter(lang) {
+  const labels = (texts[lang] && texts[lang].contact) || {};
+  const phoneLink = document.getElementById('footer-phone');
+  const emailLink = document.getElementById('footer-email');
+  const yearEl = document.getElementById('year');
+  const siteNameEl = document.getElementById('site-name');
+
+  if (phoneLink && config.contact && config.contact.phone) {
+    phoneLink.textContent = `${labels.phone || 'Teléfono'}: ${config.contact.phone}`;
+    phoneLink.href = `tel:${config.contact.phone}`;
+  }
+
+  if (emailLink && config.contact && config.contact.email) {
+    emailLink.textContent = config.contact.email;
+    emailLink.href = `mailto:${config.contact.email}`;
+  }
+
+  if (yearEl) {
+    yearEl.textContent = new Date().getFullYear();
+  }
+
+  if (siteNameEl && config.site && config.site.name) {
+    siteNameEl.textContent = config.site.name;
+  }
+}
+
 function handleGalleryKeys(e) {
   const modal = document.getElementById('gallery-modal');
   if (!modal || !modal.classList.contains('active')) return;
@@ -436,6 +462,7 @@ function renderUI(lang) {
   renderAmenities(lang);
   renderGallery();
   renderLocation(lang);
+  renderFooter(lang);
 }
 
 function setLanguage(lang) {

--- a/index.html
+++ b/index.html
@@ -77,7 +77,17 @@
   </main>
 
   <!-- Section: Footer -->
-  <footer id="footer"></footer>
+  <footer id="footer">
+    <div class="container">
+      <ul class="footer-links">
+        <li><a id="footer-phone" href="#"></a></li>
+        <li><a id="footer-email" href="#"></a></li>
+        <li><a href="#">Términos y condiciones</a></li>
+        <li><a href="#">Política de privacidad</a></li>
+      </ul>
+      <p>© <span id="year"></span> <span id="site-name"></span></p>
+    </div>
+  </footer>
 
   <script src="assets/js/main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add footer with contact details and placeholder policy links
- render dynamic year and site name from config
- style footer using existing color variables for accessible contrast

## Testing
- `node --check assets/js/main.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3d6aebe8832981ca8105858eccbd