### PR TITLE
Add policies and social config with dynamic languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,11 @@ cp config.example.json config.json
 ```
 
 Luego reemplaza los valores `<REPLACE_ME>` y `<REPLACE_ME_URL>` por la información real del sitio.
+
+## Nuevos campos
+
+- **site.languages**: define los idiomas disponibles del sitio como un arreglo, por ejemplo `["es", "en"]`. Puedes agregar o quitar códigos de idioma según lo necesites.
+- **policies**: lista de políticas del sitio (términos, privacidad, etc.). Cada elemento requiere un `label` por idioma y un `url`.
+- **social**: enlaces a redes sociales. Usa `platform` para identificar la red y `url` para la dirección.
+
+Duplica las entradas necesarias y reemplaza los valores `<REPLACE_ME>` y `<REPLACE_ME_URL>` con la información correspondiente.

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -102,6 +102,18 @@ function renderLogo() {
   }
 }
 
+function renderLanguageSwitcher() {
+  const selector = document.getElementById('langSwitcher');
+  if (!selector || !config.site || !Array.isArray(config.site.languages)) return;
+  selector.innerHTML = '';
+  config.site.languages.forEach((lang) => {
+    const option = document.createElement('option');
+    option.value = lang;
+    option.textContent = lang.toUpperCase();
+    selector.appendChild(option);
+  });
+}
+
 function renderNav(lang) {
   const list = document.getElementById('nav-items');
   if (!list || !config.nav || !Array.isArray(config.nav.items)) return;
@@ -411,6 +423,8 @@ function renderFooter(lang) {
   const labels = (texts[lang] && texts[lang].contact) || {};
   const phoneLink = document.getElementById('footer-phone');
   const emailLink = document.getElementById('footer-email');
+  const policiesList = document.getElementById('footer-policies');
+  const socialList = document.getElementById('footer-social');
   const yearEl = document.getElementById('year');
   const siteNameEl = document.getElementById('site-name');
 
@@ -422,6 +436,37 @@ function renderFooter(lang) {
   if (emailLink && config.contact && config.contact.email) {
     emailLink.textContent = config.contact.email;
     emailLink.href = `mailto:${config.contact.email}`;
+  }
+
+  if (policiesList) {
+    policiesList.innerHTML = '';
+    if (Array.isArray(config.policies)) {
+      config.policies.forEach((item) => {
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        const label = (item.label && (item.label[lang] || item.label)) || '';
+        a.textContent = label;
+        a.href = item.url || '#';
+        li.appendChild(a);
+        policiesList.appendChild(li);
+      });
+    }
+  }
+
+  if (socialList) {
+    socialList.innerHTML = '';
+    if (Array.isArray(config.social)) {
+      config.social.forEach((item) => {
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = item.url || '#';
+        a.textContent = item.platform || item.name || '';
+        a.target = '_blank';
+        a.rel = 'noopener';
+        li.appendChild(a);
+        socialList.appendChild(li);
+      });
+    }
   }
 
   if (yearEl) {
@@ -565,8 +610,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   config = await loadConfig();
   renderLogo();
   setColors();
+  renderLanguageSwitcher();
   const stored = localStorage.getItem('lang');
-  const defaultLang = (config.site && config.site.defaultLang) || 'es';
+  const defaultLang = (config.site && config.site.defaultLang) || (config.site && config.site.languages && config.site.languages[0]) || 'es';
   setLanguage(stored || defaultLang);
   const selector = document.getElementById('langSwitcher');
   if (selector) {

--- a/config.example.json
+++ b/config.example.json
@@ -10,6 +10,7 @@
     "description": "<REPLACE_ME>",
     "baseUrl": "<REPLACE_ME_URL>",
     "defaultLang": "es",
+    "languages": ["es", "en", "pt"],
     "heroImage": "<REPLACE_ME_URL>"
   },
   "colors": {
@@ -60,6 +61,12 @@
       "quote": "<REPLACE_ME>",
       "avatarUrl": "<REPLACE_ME_URL>"
     }
+  ],
+  "policies": [
+    { "label": { "es": "<REPLACE_ME>", "en": "<REPLACE_ME>" }, "url": "<REPLACE_ME_URL>" }
+  ],
+  "social": [
+    { "platform": "<REPLACE_ME>", "url": "<REPLACE_ME_URL>" }
   ],
   "seo": {
     "metaTitle": "<REPLACE_ME>",

--- a/config.json
+++ b/config.json
@@ -9,7 +9,11 @@
     "description": "Tu hogar lejos de casa",
     "baseUrl": "https://hotelparaiso.example",
     "defaultLang": "es",
-    "logo": "assets/img/logo.svg"
+    "logo": "assets/img/logo.svg",
+    "languages": [
+      "es",
+      "en"
+    ]
   },
   "colors": {
     "primary": "#005f73",
@@ -34,11 +38,41 @@
   },
   "nav": {
     "items": [
-      { "section": "hero", "label": { "es": "Inicio", "en": "Home" } },
-      { "section": "rooms", "label": { "es": "Habitaciones", "en": "Rooms" } },
-      { "section": "amenities", "label": { "es": "Servicios", "en": "Amenities" } },
-      { "section": "gallery", "label": { "es": "Galería", "en": "Gallery" } },
-      { "section": "location", "label": { "es": "Ubicación", "en": "Location" } }
+      {
+        "section": "hero",
+        "label": {
+          "es": "Inicio",
+          "en": "Home"
+        }
+      },
+      {
+        "section": "rooms",
+        "label": {
+          "es": "Habitaciones",
+          "en": "Rooms"
+        }
+      },
+      {
+        "section": "amenities",
+        "label": {
+          "es": "Servicios",
+          "en": "Amenities"
+        }
+      },
+      {
+        "section": "gallery",
+        "label": {
+          "es": "Galería",
+          "en": "Gallery"
+        }
+      },
+      {
+        "section": "location",
+        "label": {
+          "es": "Ubicación",
+          "en": "Location"
+        }
+      }
     ]
   },
   "rooms": [
@@ -69,6 +103,21 @@
         "en": "Comfortable room"
       },
       "price": 90
+    }
+  ],
+  "policies": [
+    {
+      "label": {
+        "es": "<REPLACE_ME>",
+        "en": "<REPLACE_ME>"
+      },
+      "url": "<REPLACE_ME_URL>"
+    }
+  ],
+  "social": [
+    {
+      "platform": "<REPLACE_ME>",
+      "url": "<REPLACE_ME_URL>"
     }
   ]
 }

--- a/index.html
+++ b/index.html
@@ -21,10 +21,7 @@
     <nav id="nav" aria-label="Principal">
       <ul id="nav-items"></ul>
     </nav>
-    <select id="langSwitcher" aria-label="Cambiar idioma">
-      <option value="es">ES</option>
-      <option value="en">EN</option>
-    </select>
+    <select id="langSwitcher" aria-label="Cambiar idioma"></select>
     <button id="reserve-btn" class="btn btn-primary">Reservar</button>
   </header>
 
@@ -79,12 +76,12 @@
   <!-- Section: Footer -->
   <footer id="footer">
     <div class="container">
-      <ul class="footer-links">
+      <ul id="footer-contact" class="footer-links">
         <li><a id="footer-phone" href="#"></a></li>
         <li><a id="footer-email" href="#"></a></li>
-        <li><a href="#">Términos y condiciones</a></li>
-        <li><a href="#">Política de privacidad</a></li>
       </ul>
+      <ul id="footer-policies" class="footer-links"></ul>
+      <ul id="footer-social" class="footer-links"></ul>
       <p>© <span id="year"></span> <span id="site-name"></span></p>
     </div>
   </footer>


### PR DESCRIPTION
## Summary
- support dynamic `site.languages` in configuration and UI
- add configurable `policies` and `social` sections with placeholders
- document new fields in README for easy duplication

## Testing
- `node --check assets/js/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae42207f34832985468c6a1c8af181