### PR TITLE
feat: add SEO metadata and crawler files

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -80,8 +80,41 @@ function applySEO(lang) {
   document.getElementById('meta-description').setAttribute('content', metaDescription);
   document.getElementById('og-title').setAttribute('content', metaTitle);
   document.getElementById('og-description').setAttribute('content', metaDescription);
+  const baseUrl = (config.site && config.site.baseUrl) || '';
+  document.getElementById('og-url').setAttribute('content', baseUrl);
+  document.getElementById('twitter-url').setAttribute('content', baseUrl);
+  document.getElementById('twitter-title').setAttribute('content', metaTitle);
+  document.getElementById('twitter-description').setAttribute('content', metaDescription);
+  document.getElementById('og-type').setAttribute('content', 'website');
+  document.getElementById('twitter-card').setAttribute('content', 'summary_large_image');
   if (config.seo && config.seo.metaImageUrl) {
     document.getElementById('og-image').setAttribute('content', config.seo.metaImageUrl);
+    document.getElementById('twitter-image').setAttribute('content', config.seo.metaImageUrl);
+  }
+}
+
+function insertHotelSchema() {
+  if (!config.site || !config.contact) return;
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'Hotel',
+    name: config.site.name || '',
+    url: config.site.baseUrl || '',
+    address: {
+      '@type': 'PostalAddress',
+      streetAddress: (config.contact && config.contact.address) || ''
+    },
+    telephone: (config.contact && config.contact.phone) || ''
+  };
+  if (config.booking && config.booking.checkinTime) {
+    schema.checkinTime = config.booking.checkinTime;
+  }
+  if (config.booking && config.booking.checkoutTime) {
+    schema.checkoutTime = config.booking.checkoutTime;
+  }
+  const el = document.getElementById('hotel-schema');
+  if (el) {
+    el.textContent = JSON.stringify(schema);
   }
 }
 
@@ -611,6 +644,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   renderLogo();
   setColors();
   renderLanguageSwitcher();
+  insertHotelSchema();
   const stored = localStorage.getItem('lang');
   const defaultLang = (config.site && config.site.defaultLang) || (config.site && config.site.languages && config.site.languages[0]) || 'es';
   setLanguage(stored || defaultLang);

--- a/config.example.json
+++ b/config.example.json
@@ -27,7 +27,9 @@
     "booking": {
       "mode": "whatsapp",
       "externalUrl": "<REPLACE_ME_URL>",
-      "currency": "<REPLACE_ME_CURRENCY>"
+      "currency": "<REPLACE_ME_CURRENCY>",
+      "checkinTime": "<REPLACE_ME>",
+      "checkoutTime": "<REPLACE_ME>"
     },
   "branding": {
     "logoUrl": "<REPLACE_ME_URL>",

--- a/config.json
+++ b/config.json
@@ -34,7 +34,9 @@
   "booking": {
     "mode": "whatsapp",
     "externalUrl": "https://booking.example",
-    "currency": "USD"
+    "currency": "USD",
+    "checkinTime": "15:00",
+    "checkoutTime": "11:00"
   },
   "nav": {
     "items": [

--- a/index.html
+++ b/index.html
@@ -12,6 +12,14 @@
   <meta property="og:title" content="" id="og-title">
   <meta property="og:description" content="" id="og-description">
   <meta property="og:image" content="" id="og-image">
+  <meta property="og:url" content="" id="og-url">
+  <meta property="og:type" content="website" id="og-type">
+  <meta name="twitter:card" content="summary_large_image" id="twitter-card">
+  <meta name="twitter:title" content="" id="twitter-title">
+  <meta name="twitter:description" content="" id="twitter-description">
+  <meta name="twitter:image" content="" id="twitter-image">
+  <meta name="twitter:url" content="" id="twitter-url">
+  <script type="application/ld+json" id="hotel-schema"></script>
   <link rel="stylesheet" href="assets/css/styles.css">
 </head>
 <body>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://hotelparaiso.example/</loc>
+  </url>
+  <url>
+    <loc>https://hotelparaiso.example/index.html</loc>
+  </url>
+  <url>
+    <loc>https://hotelparaiso.example/robots.txt</loc>
+  </url>
+  <url>
+    <loc>https://hotelparaiso.example/sitemap.xml</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- add Open Graph/Twitter meta tags and inject Hotel JSON-LD schema
- expose check-in and check-out times in config
- create robots.txt and sitemap.xml for basic crawling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae44b207b4832980c1e262a57eef75