### PR TITLE
feat: auto-apply high-contrast palette on WCAG failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,28 @@ Luego reemplaza los valores `<REPLACE_ME>` y `<REPLACE_ME_URL>` por la informaci
 - **social**: enlaces a redes sociales. Usa `platform` para identificar la red y `url` para la dirección.
 
 Duplica las entradas necesarias y reemplaza los valores `<REPLACE_ME>` y `<REPLACE_ME_URL>` con la información correspondiente.
+
+## Modo de alto contraste
+
+El archivo `main.js` verifica el contraste de los colores definidos y, si alguna
+combinación no cumple con el nivel AA de las WCAG (4.5:1), añade la clase
+global `high-contrast` al elemento `<html>` para sustituir las variables CSS por
+una paleta accesible.
+
+### Activación manual
+
+```html
+<html class="high-contrast">
+```
+
+O desde la consola de DevTools:
+
+```javascript
+document.documentElement.classList.add('high-contrast');
+```
+
+### Pruebas con DevTools
+
+Abre las herramientas de desarrollador, selecciona el elemento `<html>` y
+agrega o elimina la clase `high-contrast` para observar los cambios en las
+variables CSS y comprobar el contraste.


### PR DESCRIPTION
## Summary
- check primary, accent, and text color pairs with WCAG formula
- add `high-contrast` class when a pair fails and override CSS variables
- document how to activate the high-contrast mode and test via DevTools

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae461393448329b4bcabc0f028aa46