### PR TITLE
feat: externalize UI translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ Luego reemplaza los valores `<REPLACE_ME>` y `<REPLACE_ME_URL>` por la informaci
 
 Duplica las entradas necesarias y reemplaza los valores `<REPLACE_ME>` y `<REPLACE_ME_URL>` con la información correspondiente.
 
+## Traducciones
+
+Los textos de la interfaz se cargan desde archivos JSON ubicados en la carpeta `i18n`. Cada archivo debe nombrarse con el código de idioma, por ejemplo `i18n/fr.json`, y seguir la estructura de los archivos existentes (`es.json`, `en.json`).
+
+Para agregar un nuevo idioma:
+
+1. Crea el archivo `i18n/<codigo>.json` con todas las claves necesarias.
+2. Añade el código del idioma al arreglo `site.languages` en `config.json`.
+3. Si deseas que sea el idioma predeterminado, actualiza `site.defaultLang`.
+
+Si falta alguna clave en un idioma, el sitio usará automáticamente el valor del idioma por defecto.
+
 ## Modo de alto contraste
 
 El archivo `main.js` verifica el contraste de los colores definidos y, si alguna

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,17 @@
+{
+  "heroRoomsBtn": "View rooms",
+  "heroReserveBtn": "Book",
+  "bookingCta": "Book now",
+  "contact": {
+    "phone": "Phone",
+    "whatsapp": "WhatsApp",
+    "email": "Email",
+    "address": "Address",
+    "openMap": "Open map",
+    "directions": "Directions"
+  },
+  "seo": {
+    "metaTitle": "Paradise Hotel",
+    "metaDescription": "Discover the best accommodation."
+  }
+}

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -1,0 +1,17 @@
+{
+  "heroRoomsBtn": "Ver habitaciones",
+  "heroReserveBtn": "Reservar",
+  "bookingCta": "Reservar ahora",
+  "contact": {
+    "phone": "Teléfono",
+    "whatsapp": "WhatsApp",
+    "email": "Email",
+    "address": "Dirección",
+    "openMap": "Abrir mapa",
+    "directions": "Cómo llegar"
+  },
+  "seo": {
+    "metaTitle": "Hotel Paraíso",
+    "metaDescription": "Descubre el mejor alojamiento."
+  }
+}


### PR DESCRIPTION
## Summary
- load UI dictionaries from `i18n/*.json` with default-language fallback
- populate language selector and UI text using loaded translations
- document how to add new translation files

## Testing
- `node --check assets/js/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4a22072c83298b02e96192d95ec0