### PR TITLE
feat: add responsive header navigation

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -47,10 +47,35 @@ header {
   width: 100%;
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: var(--spacing-md);
   padding: var(--spacing-sm) var(--spacing-md);
   background-color: var(--color-bg);
   z-index: 1000;
+}
+
+.nav-toggle {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.primary-navigation {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  display: none;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--spacing-md);
+  padding: var(--spacing-md);
+  background-color: var(--color-bg);
+}
+
+.nav-toggle[aria-expanded="true"] + .primary-navigation {
+  display: flex;
 }
 
 main {
@@ -62,6 +87,7 @@ main {
   margin: 0;
   padding: 0;
   display: flex;
+  flex-direction: column;
   gap: var(--spacing-md);
 }
 
@@ -82,6 +108,23 @@ select:focus-visible,
 textarea:focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
+}
+
+@media (min-width: 768px) {
+  .nav-toggle {
+    display: none;
+  }
+  .primary-navigation {
+    position: static;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: var(--spacing-md);
+    padding: 0;
+  }
+  #nav-items {
+    flex-direction: row;
+  }
 }
 
 /* Utility classes */

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -807,5 +807,17 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (widget) widget.scrollIntoView({ behavior: 'smooth' });
     });
   }
+  const navToggle = document.querySelector('.nav-toggle');
+  const nav = document.getElementById('primary-nav');
+  if (navToggle && nav) {
+    navToggle.addEventListener('click', () => {
+      const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+      navToggle.setAttribute('aria-expanded', String(!expanded));
+      if (!expanded) {
+        const firstLink = nav.querySelector('a');
+        if (firstLink) firstLink.focus();
+      }
+    });
+  }
   setupBookingForm();
 });

--- a/index.html
+++ b/index.html
@@ -20,6 +20,21 @@
     <link rel="stylesheet" href="/assets/css/styles.css">
   </head>
   <body>
+    <header id="top" class="site-header">
+      <a href="#top" id="logo"><REPLACE_ME></a>
+      <button
+        class="nav-toggle"
+        aria-controls="primary-nav"
+        aria-expanded="false"
+        aria-label="Menú"
+      >
+        ☰
+      </button>
+      <nav id="primary-nav" class="primary-navigation">
+        <ul id="nav-items"></ul>
+        <button id="reserve-btn" class="btn btn-primary">Reservar</button>
+      </nav>
+    </header>
     <script src="/assets/js/main.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add fixed header with logo placeholder, nav links and reserve button
- implement responsive nav with mobile toggle and desktop layout
- handle menu toggle in JavaScript with focus management

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check assets/js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae512d602c8329b5686a8de1dc110a