### PR TITLE
Add hero section with background overlay

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -251,25 +251,41 @@ textarea:focus-visible {
   justify-content: center;
   min-height: 70vh;
   color: var(--color-text-light);
-  background-size: cover;
-  background-position: center;
   text-align: center;
+  overflow: hidden;
 }
 
 #hero::before {
   content: "";
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: linear-gradient(var(--color-primary), var(--color-primary));
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: 1;
 }
 
-#hero.hero-no-image {
-  background-color: var(--color-primary);
+#hero .hero-bg {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  z-index: 0;
+  display: none;
+}
+
+#hero.is-has-bg .hero-bg {
+  display: block;
+}
+
+#hero.is-has-bg::before {
+  opacity: 0.6;
 }
 
 #hero .container {
   position: relative;
-  z-index: 1;
+  z-index: 2;
 }
 
 .hero-actions {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -819,5 +819,9 @@ document.addEventListener('DOMContentLoaded', async () => {
       }
     });
   }
+  const hero = document.getElementById('hero');
+  if (hero && hero.querySelector('.hero-bg')) {
+    hero.classList.add('is-has-bg');
+  }
   setupBookingForm();
 });

--- a/index.html
+++ b/index.html
@@ -35,6 +35,17 @@
         <button id="reserve-btn" class="btn btn-primary">Reservar</button>
       </nav>
     </header>
+    <section id="hero">
+      <div class="container">
+        <h1><REPLACE_ME></h1>
+        <p><REPLACE_ME></p>
+        <div class="hero-actions">
+          <a href="#rooms" class="btn btn-secondary">Habitaciones</a>
+          <a href="#booking" class="btn btn-primary">Reservar</a>
+        </div>
+      </div>
+      <div class="hero-bg"><!-- EDIT_ME: colocar imagen CSS más adelante --></div>
+    </section>
     <script src="/assets/js/main.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Add hero section with headline, subtitle, calls to action and placeholder background element
- Style hero with optional background image, gradient overlay and min-height
- Enable JavaScript to toggle hero background visibility based on markup

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5636ac188329a056ec3929ce04a8