### PR TITLE
feat: add direct booking widget placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,19 @@ document.documentElement.classList.add('high-contrast');
 Abre las herramientas de desarrollador, selecciona el elemento `<html>` y
 agrega o elimina la clase `high-contrast` para observar los cambios en las
 variables CSS y comprobar el contraste.
+
+## Widget de reserva
+
+La sección `#booking` en `index.html` contiene un `<div>` vacío con `id="booster-root"`
+marcado con `data-widget="direct-booking-placeholder"`. Un script externo debe
+montar el widget de reserva dentro de este elemento, por ejemplo:
+
+```html
+<script src="https://example.com/direct-booking.js"></script>
+<script>
+  window.DirectBooking.mount('#booster-root');
+</script>
+```
+
+Este snippet busca el contenedor y reemplaza su contenido con el widget real de
+reserva.

--- a/index.html
+++ b/index.html
@@ -46,6 +46,12 @@
       </div>
       <div class="hero-bg"><!-- EDIT_ME: colocar imagen CSS más adelante --></div>
     </section>
+    <section id="booking" aria-labelledby="booking-title">
+      <h2 id="booking-title">Reserva directa</h2>
+      <div id="booster-root" data-widget="direct-booking-placeholder"></div>
+      <p>Aquí irá el widget de reserva. (EDIT_ME)</p>
+      <div class="visually-hidden" aria-live="polite"></div>
+    </section>
     <script src="/assets/js/main.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add booking section placeholder for future direct booking widget
- document mounting instructions in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5724aa188329b70b739cd307288f