### PR TITLE
Add rooms and amenities sections with responsive grid and cards

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -20,6 +20,7 @@
   --spacing-sm: 0.5rem;
   --spacing-md: 1rem;
   --spacing-lg: 2rem;
+  --radius: 0.5rem;
 }
 
 /* Global rules */
@@ -152,20 +153,30 @@ textarea:focus-visible {
 .grid {
   display: grid;
   gap: var(--spacing-md);
+}
+
+.grid-3 {
   grid-template-columns: 1fr;
+}
+
+@media (min-width: 768px) {
+  .grid-3 {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }
 
 .card {
   background-color: var(--color-bg);
-  border: 1px solid var(--color-primary);
-  border-radius: 4px;
+  border-radius: var(--radius);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   padding: var(--spacing-md);
 }
 
-.room-card img {
+.room-card img,
+.room img {
   width: 100%;
   height: auto;
-  border-radius: 4px;
+  border-radius: var(--radius);
 }
 
 #gallery img {
@@ -178,13 +189,15 @@ textarea:focus-visible {
 }
 
 
-.amenity-item {
+.amenity-item,
+.amenity {
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
 }
 
-.amenity-icon {
+.amenity-icon,
+.amenity .icon {
   font-size: 1.5rem;
 }
 

--- a/index.html
+++ b/index.html
@@ -46,6 +46,37 @@
       </div>
       <div class="hero-bg"><!-- EDIT_ME: colocar imagen CSS más adelante --></div>
     </section>
+    <section id="rooms">
+      <h2>Habitaciones</h2>
+      <div class="grid grid-3">
+        <article class="card room">
+          <img src="" alt="<REPLACE_ME>">
+          <h3><REPLACE_ME></h3>
+          <p><REPLACE_ME></p>
+          <p class="price">Desde <REPLACE_ME_CURRENCY></p>
+        </article>
+        <article class="card room">
+          <img src="" alt="<REPLACE_ME>">
+          <h3><REPLACE_ME></h3>
+          <p><REPLACE_ME></p>
+          <p class="price">Desde <REPLACE_ME_CURRENCY></p>
+        </article>
+        <article class="card room">
+          <img src="" alt="<REPLACE_ME>">
+          <h3><REPLACE_ME></h3>
+          <p><REPLACE_ME></p>
+          <p class="price">Desde <REPLACE_ME_CURRENCY></p>
+        </article>
+      </div>
+    </section>
+    <section id="amenities">
+      <h2>Servicios</h2>
+      <ul class="grid grid-3">
+        <li class="amenity"><span class="icon">🛏️</span><span class="label"><REPLACE_ME></span></li>
+        <li class="amenity"><span class="icon">🛏️</span><span class="label"><REPLACE_ME></span></li>
+        <li class="amenity"><span class="icon">🛏️</span><span class="label"><REPLACE_ME></span></li>
+      </ul>
+    </section>
     <section id="booking" aria-labelledby="booking-title">
       <h2 id="booking-title">Reserva directa</h2>
       <div id="booster-root" data-widget="direct-booking-placeholder"></div>


### PR DESCRIPTION
## Summary
- add `Habitaciones` and `Servicios` sections with placeholder content
- implement `.grid-3` and card styling using `--radius` and box shadow
- align amenity icons and labels with flexbox

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae57c5ee0083299ea8df649d84c729