### PR TITLE
Add gallery and location sections with modal

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -226,7 +226,7 @@ textarea:focus-visible {
   display: none;
   align-items: center;
   justify-content: center;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: rgba(0, 0, 0, 0.8);
 }
 
 .modal.active {
@@ -234,6 +234,7 @@ textarea:focus-visible {
 }
 
 .modal-content {
+  position: relative;
   background-color: var(--color-bg);
   padding: var(--spacing-lg);
   border-radius: 8px;
@@ -248,6 +249,12 @@ textarea:focus-visible {
   color: var(--color-text-light);
   font-size: 2rem;
   cursor: pointer;
+}
+
+.modal img {
+  max-width: 90vw;
+  max-height: 90vh;
+  border-radius: 4px;
 }
 
 .gallery-modal img {
@@ -353,6 +360,23 @@ textarea:focus-visible {
 #location .btn {
   margin-right: var(--spacing-sm);
   margin-top: var(--spacing-md);
+}
+
+#location address {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-md);
+}
+
+#location address a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+#location address a:hover,
+#location address a:focus-visible {
+  text-decoration: underline;
 }
 
 /* High contrast mode */

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -779,6 +779,51 @@ function setupBookingForm() {
   );
 }
 
+function setupGalleryModal() {
+  const images = document.querySelectorAll('#gallery img[data-full]');
+  if (!images.length) return;
+
+  const modal = document.createElement('div');
+  modal.id = 'gallery-modal';
+  modal.className = 'modal';
+  modal.innerHTML =
+    '<div class="modal-content"><button class="modal-close" aria-label="Cerrar">&times;</button><img src="" alt=""></div>';
+  document.body.appendChild(modal);
+
+  const modalImg = modal.querySelector('img');
+  const closeBtn = modal.querySelector('.modal-close');
+  let lastFocused = null;
+
+  function open(src, alt) {
+    lastFocused = document.activeElement;
+    modalImg.src = src;
+    modalImg.alt = alt;
+    modal.classList.add('active');
+    closeBtn.focus();
+  }
+
+  function close() {
+    modal.classList.remove('active');
+    modalImg.src = '';
+    if (lastFocused) lastFocused.focus();
+  }
+
+  images.forEach((img) => {
+    img.addEventListener('click', () => open(img.dataset.full || img.src, img.alt));
+  });
+
+  closeBtn.addEventListener('click', close);
+  modal.addEventListener('click', (e) => {
+    if (e.target === modal) close();
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && modal.classList.contains('active')) {
+      close();
+    }
+  });
+}
+
 document.addEventListener('DOMContentLoaded', async () => {
   config = await loadConfig();
   defaultLang =
@@ -823,5 +868,6 @@ document.addEventListener('DOMContentLoaded', async () => {
   if (hero && hero.querySelector('.hero-bg')) {
     hero.classList.add('is-has-bg');
   }
+  setupGalleryModal();
   setupBookingForm();
 });

--- a/index.html
+++ b/index.html
@@ -77,6 +77,32 @@
         <li class="amenity"><span class="icon">🛏️</span><span class="label"><REPLACE_ME></span></li>
       </ul>
     </section>
+    <section id="gallery">
+      <h2>Galería</h2>
+      <div class="grid grid-3">
+        <figure>
+          <img src="" alt="<REPLACE_ME>" data-full="">
+          <figcaption class="sr-only"><REPLACE_ME></figcaption>
+        </figure>
+        <figure>
+          <img src="" alt="<REPLACE_ME>" data-full="">
+          <figcaption class="sr-only"><REPLACE_ME></figcaption>
+        </figure>
+        <figure>
+          <img src="" alt="<REPLACE_ME>" data-full="">
+          <figcaption class="sr-only"><REPLACE_ME></figcaption>
+        </figure>
+      </div>
+    </section>
+    <section id="location">
+      <h2>Ubicación</h2>
+      <iframe src="" title="Mapa" loading="lazy"><!-- EDIT_ME: pegar mapEmbedUrl --></iframe>
+      <address>
+        <a href="tel:<REPLACE_ME>"><REPLACE_ME></a>
+        <a href="mailto:<REPLACE_ME>"><REPLACE_ME></a>
+        <button class="btn btn-secondary" onclick="location.href='<REPLACE_ME_GOOGLE_MAPS_URL>'">Cómo llegar</button>
+      </address>
+    </section>
     <section id="booking" aria-labelledby="booking-title">
       <h2 id="booking-title">Reserva directa</h2>
       <div id="booster-root" data-widget="direct-booking-placeholder"></div>


### PR DESCRIPTION
## Summary
- add gallery and location sections to landing page
- implement accessible image modal behavior
- style modal overlay and location contact block

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae589d9160832998cf82be54df554f