### PR TITLE
Document template structure and add skip link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,16 @@
 
 # Hoteles
 
-Estructura básica para el proyecto Hoteles.
+Plantilla mínima para crear sitios de hoteles estáticos.
+
+## Estructura de carpetas
+
+- `assets/css/`: hoja de estilos principal (`styles.css`).
+- `assets/img/`: imágenes del sitio.
+- `assets/js/`: scripts de interacción.
+- `i18n/`: archivos de traducción.
+- `index.html`: página base de ejemplo.
+- `config.json`: configuración del sitio.
 
 ## Configuración
 
@@ -24,6 +33,17 @@ Luego reemplaza los valores `<REPLACE_ME>` y `<REPLACE_ME_URL>` por la informaci
 - **social**: enlaces a redes sociales. Usa `platform` para identificar la red y `url` para la dirección.
 
 Duplica las entradas necesarias y reemplaza los valores `<REPLACE_ME>` y `<REPLACE_ME_URL>` con la información correspondiente.
+
+## Personalización de estilos e imágenes
+
+### Variables CSS
+Edita `assets/css/styles.css` en el bloque `:root` para ajustar colores, radios y espaciados. Se incluye un bloque `@media (prefers-color-scheme: dark)` para adaptar los tonos en modo oscuro si lo deseas.
+
+### Imágenes
+Sube los archivos a `assets/img/` y referencia su ruta desde HTML o CSS.
+
+### Marcadores `<REPLACE_ME>` y `EDIT_ME`
+Busca estos marcadores en todo el proyecto y sustitúyelos por la información real del sitio.
 
 ## Traducciones
 
@@ -69,11 +89,19 @@ marcado con `data-widget="direct-booking-placeholder"`. Un script externo debe
 montar el widget de reserva dentro de este elemento, por ejemplo:
 
 ```html
-<script src="https://example.com/direct-booking.js"></script>
+<script src="/widget/booster.js" defer></script>
 <script>
-  window.DirectBooking.mount('#booster-root');
+  window.addEventListener('load', () => {
+    BOOster.mount('#booster-root','<REPLACE_ME_CONFIG_URL>')
+  });
 </script>
 ```
 
 Este snippet busca el contenedor y reemplaza su contenido con el widget real de
 reserva.
+
+## Recomendaciones
+
+- Asegura un contraste mínimo de 4.5:1 entre texto y fondo.
+- Utiliza unidades relativas (`rem`) y las variables `--space-*` para tamaños y espaciado.
+- Para agregar nuevas secciones, duplica un bloque `<section>` en `index.html`, asigna un `id` único y actualiza la navegación.

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -14,6 +14,14 @@
   --space-3: 2rem;
 }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg: #1a1a1a; /* EDIT_ME */
+    --color-text: #f0f0f0; /* EDIT_ME */
+    --color-muted: #999999; /* EDIT_ME */
+  }
+}
+
 /* Global rules */
 *, *::before, *::after {
   box-sizing: border-box;
@@ -24,6 +32,22 @@ body {
   font-family: system-ui, sans-serif;
   color: var(--color-text);
   background: var(--color-bg);
+}
+
+.skip-link {
+  position: absolute;
+  left: var(--space-2);
+  top: -40px;
+  padding: var(--space-1) var(--space-2);
+  background: var(--color-primary);
+  color: #fff;
+  border-radius: var(--radius);
+  text-decoration: none;
+  transition: top 0.2s;
+}
+
+.skip-link:focus {
+  top: var(--space-2);
 }
 
 /* Utilities */

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
     <link rel="stylesheet" href="/assets/css/styles.css">
   </head>
   <body>
+    <a href="#hero" class="skip-link">Saltar al contenido</a>
     <header id="top" class="site-header">
       <a href="#top" id="logo"><REPLACE_ME></a>
       <button


### PR DESCRIPTION
## Summary
- document template purpose, folder structure, and customization instructions
- provide booking widget snippet and accessibility recommendations
- add keyboard skip link and optional dark color scheme

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5d634d9883298a6de84aac5b207c